### PR TITLE
Storable align instance used component of sizeOf instead of align

### DIFF
--- a/library/Record/TH.hs
+++ b/library/Record/TH.hs
@@ -171,7 +171,7 @@ recordStorableInstanceDec strict arity =
                    [(Clause [WildP]
                      (NormalB (AppE (nameE "maximum") $ ListE $
                                map (\i -> AppE
-                                          (nameE "sizeOf")
+                                          (nameE "alignment")
                                           (SigE (nameE "undefined")
                                                 (VarT (mkName ("v" <> show i)))))
                                [1..arity])) [])]


### PR DESCRIPTION
The comment indicates it should be maximum of alignment called on the sub-components, which makes more sense than the current maximum of sizeOf.  Likely just a typo or cut and paste error.
